### PR TITLE
Add replace function

### DIFF
--- a/jmespath.js
+++ b/jmespath.js
@@ -4845,6 +4845,14 @@
 	    _func: ([s]) => s.toLowerCase(),
 	    _signature: [{types: [jmespath.types.TYPE_STRING]}]
 	  },
+	  replace: {
+		_func: ([s, v, nv]) => s.replace(v, nv),
+		_signature: [
+		{types: [jmespath.types.TYPE_STRING]},
+		{types: [jmespath.types.TYPE_STRING]},
+		{types: [jmespath.types.TYPE_STRING]}
+	  ]
+	  },
 	  trim: {
 	    _func: ([s]) => s.trim(),
 	    _signature: [{types: [jmespath.types.TYPE_STRING]}]

--- a/jmespath.js
+++ b/jmespath.js
@@ -4846,7 +4846,7 @@
 	    _signature: [{types: [jmespath.types.TYPE_STRING]}]
 	  },
 	  replace: {
-		_func: ([s, v, nv]) => s.replace(v, nv),
+		_func: ([s, v, nv]) => s.replace(new RegExp(v), nv),
 		_signature: [
 		{types: [jmespath.types.TYPE_STRING]},
 		{types: [jmespath.types.TYPE_STRING]},

--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,7 @@ const functions = {
     _signature: [{types: [jmespath.types.TYPE_STRING]}]
   },
   replace: {
-    _func: ([s, v, nv]) => s.replace(v, nv),
+    _func: ([s, v, nv]) => s.replace(new RegExp(v), nv),
     _signature: [
     {types: [jmespath.types.TYPE_STRING]},
     {types: [jmespath.types.TYPE_STRING]},

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,14 @@ const functions = {
     _func: ([s]) => s.toLowerCase(),
     _signature: [{types: [jmespath.types.TYPE_STRING]}]
   },
+  replace: {
+    _func: ([s, v, nv]) => s.replace(v, nv),
+    _signature: [
+    {types: [jmespath.types.TYPE_STRING]},
+    {types: [jmespath.types.TYPE_STRING]},
+    {types: [jmespath.types.TYPE_STRING]}
+  ]
+  },
   trim: {
     _func: ([s]) => s.trim(),
     _signature: [{types: [jmespath.types.TYPE_STRING]}]

--- a/test/utils.js
+++ b/test/utils.js
@@ -4,6 +4,15 @@ var search = jmespath.search;
 
 describe('custom functions', function() {
   it(
+    'string replace',
+    function() {
+      const data = { foo: "test"};
+      const expr = "replace(foo, 'test', 'a')";
+      const value = search(data, expr);
+      assert.equal(value, "a");
+    }
+  );
+  it(
     'string toLowerCase',
     function() {
       const data = { foo: "aMixedCaseThing"};


### PR DESCRIPTION
I would like to add the ability to replace a string. In my particular case that would help me to handle sort_by of potential null values.
For example trying to sort this json by name: sort_by(people, &name)

{
     "people": [
                          { ,
                               "name": "aName"
                          },
                          { 
                               "name": null
                          },
                          { 
                               "name": "mName"
                          },
                     ]
}

would fail because sort_by can't handle null values, so you need to do:

           sort_by(people, &to_string(name))

but in that case, null is considered as a string "null", so it is sorted between "aName" and "mName".
Using the replace function we can set the string "null" to an empty string so it would be sorted as an empty string which seems to be more accurate.

The jmespath query will look like:

           sort_by(people, &replace(to_string(name), "^null$", "")
